### PR TITLE
Docs: Fix issue with missing script in documentation

### DIFF
--- a/docs/showcase/modules/ROOT/pages/build-and-deploy.adoc
+++ b/docs/showcase/modules/ROOT/pages/build-and-deploy.adoc
@@ -18,9 +18,8 @@ $ git checkout{showcase-version}
 [source,bash,subs="attributes"]
 ----
 $ npm install
-$ npm run ionic:build
+$ npm run build:prod
 ----
-
 
 . Run the Mobile App on a device if connected or on the emulator if no device is connected:
 +


### PR DESCRIPTION
Script was renamed. I have added new command and verified entire procedure. 

```
[wtrocki@wtrockigraph ionic-showcase (master)]$ npm run ionic:build --prod
npm ERR! missing script: ionic:build
npm ERR! 
npm ERR! Did you mean one of these?
npm ERR!     ionic:ios
npm ERR!     ionic:pwa

```
 